### PR TITLE
Adding session token input for assuming role from a role

### DIFF
--- a/.opspec/build/op.yml
+++ b/.opspec/build/op.yml
@@ -14,7 +14,7 @@ run:
         ref: test
         inputs: { srcDir }
     - op:
-        ref: github.com/opspec-pkgs/_.op.bootstrap#2.2.0
+        ref: github.com/opspec-pkgs/_.op.bootstrap#2.2.2
         inputs:
           srcDir:
         outputs:

--- a/README.md
+++ b/README.md
@@ -15,29 +15,28 @@ the op uses [![opspec 0.1.6](https://img.shields.io/badge/opspec-0.1.6-brightgre
 ## Install
 
 ```shell
-opctl op install github.com/opspec-pkgs/aws.sts.assume-role#1.0.0
+opctl op install github.com/opspec-pkgs/aws.sts.assume-role#1.1.0
 ```
 
 ## Run
 
 ```
-opctl run github.com/opspec-pkgs/aws.sts.assume-role#1.0.0
+opctl run github.com/opspec-pkgs/aws.sts.assume-role#1.1.0
 ```
 
 ## Compose
 
 ```yaml
 op:
-  ref: github.com/opspec-pkgs/aws.sts.assume-role#1.0.0
+  ref: github.com/opspec-pkgs/aws.sts.assume-role#1.1.0
   inputs:
-    # required
-    accessKeyId:
-    roleArn:
-    roleSessionName:
-    secretAccessKey:
-    ### optional; uncomment to override default(s)
-    # region: us-west-2
-    # sessionToken: ""
+    accessKeyId:  # 👈 required; provide a value
+    roleArn:  # 👈 required; provide a value
+    roleSessionName:  # 👈 required; provide a value
+    secretAccessKey:  # 👈 required; provide a value
+  ## uncomment to override defaults
+  #   region: "us-west-2"
+  #   sessionToken: ""
   outputs:
     result:
 ```

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ op:
     secretAccessKey:
     ### optional; uncomment to override default(s)
     # region: us-west-2
+    # sessionToken: ""
   outputs:
     result:
 ```

--- a/op.yml
+++ b/op.yml
@@ -31,7 +31,7 @@ inputs:
       isSecret: true
   sessionToken:
     string:
-      description: session token from temporary session, not required
+      description: default session token from temporary session
       isSecret: true
       default: ""
 outputs:
@@ -73,4 +73,4 @@ run:
     files:
       /cmd.sh:
       /result: $(result)
-version: 1.0.0
+version: 1.1.0

--- a/op.yml
+++ b/op.yml
@@ -29,6 +29,11 @@ inputs:
       constraints: { minLength: 20 }
       description: secret access key for AWS
       isSecret: true
+  sessionToken:
+    string:
+      description: session token from temporary session, not required
+      isSecret: true
+      default: ""
 outputs:
   result:
     object:
@@ -62,6 +67,7 @@ run:
       AWS_ACCESS_KEY_ID: $(accessKeyId)
       AWS_DEFAULT_REGION: $(region)
       AWS_SECRET_ACCESS_KEY: $(secretAccessKey)
+      AWS_SESSION_TOKEN: $(sessionToken)
       roleArn:
       roleSessionName:
     files:


### PR DESCRIPTION
Aws sts assume-role allows you to assume a role from an already assumed role. This PR adds an optional sessionToken input and sets the `AWS_SESSION_TOKEN` env variable to use when you have a sessionToken available.